### PR TITLE
Add namespace to android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
+    namespace 'com.hishamreffat.dynamic_app_icon'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Fixes compile error on newer android studio versions.

To test this add this to pubspec.yaml:
```
  dynamic_app_icon_flutter: #^0.0.3
    git: https://github.com/Hedon-dev/dynamic_app_icon
```